### PR TITLE
Fix/handle branch only runs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   test-command:
     description: "Specify a command to run the tests"
     required: false
+outputs:
+  coverage:
+    description: "The test coverage report"
 runs:
   using: "node12"
   main: "index.js"


### PR DESCRIPTION
The original action was only intended to update comments on PRs. This update allows running coverage on branches that don't have an associated PR.